### PR TITLE
Add tests for unsupported syntax and bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./src/index.js",
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test:debug": "node --inspect --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:watch": "node --inspect --experimental-vm-modules node_modules/jest/bin/jest.js --watch --runInBand"
   },
   "author": "",

--- a/tests/class.test.js
+++ b/tests/class.test.js
@@ -11,11 +11,16 @@ const options = {
 describe('class', () => {
   it.each([
     ['class PairClass { p }', 'class PairClass {\n  p\n}\n'],
+    // [`class PairClass {
+    //   p: string
+    //   // }
+    // }`, 'class PairClass {\n  p\n}\n'], // TODO ASI on p: string
     ['class PairClass { p = { l: 1, r: 1 }}', 'class PairClass {\n  p = {\n    l: 1,\n    r: 1\n  }\n}\n'],
     ['class PairClass<T, U> { p: Pair<T, U> = { l: 1, r: 1 }}', 'class PairClass {\n  p = {\n    l: 1,\n    r: 1\n  }\n}\n'],
     ['class PairClass<T, U> { p: Pair<T, U> }', 'class PairClass {\n  p\n}\n'],
     ['class PairClass<T, U> { p: Pair<T, U>; b: string }', 'class PairClass {\n  p\n  b\n}\n'],
     ['class PairClass<T, U> { b: { a: string }}', 'class PairClass {\n  b\n}\n'],
+    // ['class PairClass<T liliil<ddd> class{}, U> { b: { a: string }}', 'class PairClass {\n  b\n}\n'], // TODO fails because of inner "<..>"
   ])('should parse: %s', (source, expected) => {
     const ast = parser.parse(source, options)
     // Switch to a generator that supports class static fields https://github.com/estools/escodegen/issues/443

--- a/tests/function.test.js
+++ b/tests/function.test.js
@@ -21,6 +21,9 @@ describe('Function', () => {
     ['function a(arg: string = 5, arg1): Pick<{a: string}, "a"> {}', 'function a(arg = 5, arg1) {\n}'],
     ['function a(arg: string = 5, arg1): {a: string} {}', 'function a(arg = 5, arg1) {\n}'],
     ['export function a() {}', 'export function a() {\n}'],
+    // ['function a(): string {}', 'function a() {\n}'], // TODO function return type
+    // ['function a(x?: optional-type) {}', 'function a(x) {\n}'], // TODO optional parameters
+    // ['function a<T>() {}', 'function a(x) {\n}'], // TODO generics
   ])('should parse: %s', (source, expected) => {
     const ast = parser.parse(source, options)
     expect(generate(ast)).toBe(expected)

--- a/tests/import.test.js
+++ b/tests/import.test.js
@@ -11,7 +11,8 @@ const options = {
 describe('import', () => {
   it.each([
     ['import { Pair } from "./a.js"', 'import { Pair } from \'./a.js\';'],
-    ['import type { Pair } from "./a.js"\na = 1', 'a = 1;']
+    ['import type { Pair } from "./a.js"\na = 1', 'a = 1;'],
+    // ['import type * as schema from "schema";a = 1', 'a = 1;'] // TODO unsupported syntax
     //TODO: import { type Pair } from "./a.js"
   ])('should parse: %s', (source, expected) => {
     const ast = parser.parse(source, options)

--- a/tests/interface.test.js
+++ b/tests/interface.test.js
@@ -13,7 +13,8 @@ describe('interface', () => {
     ['a = 1; interface User { name: string }', 'a = 1;'],
     ['interface Pair<T, U> = { l: T; r: U }', ''],
     ['export interface Pair<T, U> = { l: T, r: U }', ''],
-    ['interface Pair<T, U> = { l: T, r: U }; a = 1', 'a = 1;'],
+    ['interface Pair<T or ddd<d>, U  or this!<[]>> = { l: T, r: U }; a = 1', 'a = 1;'],
+    ['export interface Pair<T, U> = { l: T, r: U }; a = 1', 'a = 1;'],
   ])('should parse: %s', (source, expected) => {
     const ast = parser.parse(source, options)
     expect(generate(ast)).toBe(expected)

--- a/tests/qa.test.js
+++ b/tests/qa.test.js
@@ -1,0 +1,37 @@
+import * as acorn from "acorn";
+import {toJs} from 'estree-util-to-js'
+import tacParser from "../src/tac-parser.js";
+
+const parser = acorn.Parser.extend(tacParser())
+const options = {
+  ecmaVersion: 'latest',
+  sourceType: "module",
+}
+
+describe.skip('qa', () => {
+  it('should parse lotsa crazy code', () => {
+    const source = `
+let x: string
+let y: (whatever is necessary);
+let z: whatever is necessary = 4
+
+function f(x: this<is-[really]-{good}>, y: (string extends State
+  ? ParserError<"EatWhitespace got generic string type">
+  : State extends \` \${x}\` | \`\${infer State}\`
+    ? EatWhitespace<State>
+    : State))  {}
+interface A {
+  a: !!!^^^hello!
+}
+type B = {a: string!hello?&&&, [[]]}
+class C {
+  a: string;
+  constructor(a: <>) {}
+  foo(a: !!![]) {}
+};
+function optional(x?: string) {}
+    `.trim()
+    const ast = parser.parse(source, options)
+    expect(toJs(ast).value).toBe('')
+  });
+});

--- a/tests/type-alias.test.js
+++ b/tests/type-alias.test.js
@@ -12,8 +12,14 @@ describe('type alias', () => {
   it.each([
     ['type = 5', 'type = 5;'],
     ['a = 1; type MyString = string', 'a = 1;'],
+    // ['a = 1;\ntype MyString = string\nb=1', 'a = 1;\nb = 1;'], // TODO: The problem is ASI in the first line
     ['type Pair<T, U> = { l: T r: U }', ''],
     ['type Pair<T, U> = { l: T, r: U }; a = 1', 'a = 1;'],
+    ['type Pair<T, U> = { l: T, r: U } a = 1', 'a = 1;'],
+    ['export type Pair<T, U> = { l: T, r: U } a = 1', 'a = 1;'],
+    ['export type Pair<T!! or die or [[(())]], U?!?!?!?!? right?> = { l: T, r: U } a = 1', 'a = 1;'],
+    ['export type { Pair }\na = 1', 'a = 1;'],
+    ['export type { Pair as Triplet}\na = 1', 'a = 1;'],
   ])('should parse: %s', (source, expected) => {
     const ast = parser.parse(source, options)
     expect(generate(ast)).toBe(expected)

--- a/tests/type-assertions.test.js
+++ b/tests/type-assertions.test.js
@@ -1,0 +1,19 @@
+import * as acorn from "acorn";
+import {toJs} from 'estree-util-to-js'
+import tacParser from "../src/tac-parser.js";
+
+const parser = acorn.Parser.extend(tacParser())
+const options = {
+  ecmaVersion: 'latest',
+  sourceType: "module",
+}
+
+describe.skip('type-assertions', () => {
+  it.each([
+    // ['a = 1 as number', 'a = 1'] // TODO not supported yet
+    // ['x!.a', 'x.a'] // TODO not supported yet
+  ])('should parse: %s', (source, expected) => {
+    const ast = parser.parse(source, options)
+    expect(toJs(ast).value).toBe(expected)
+  });
+});

--- a/tests/variable-types.test.js
+++ b/tests/variable-types.test.js
@@ -11,7 +11,9 @@ const options = {
 describe('Variable type', () => {
   it.each([
     ['let coord', 'let coord;'],
+    // ['let coord: string\nlet y = 4', 'let coord;\nlet y = 4;'], // TODO The problem is ASI in the first line
     ['const coord = 5', 'const coord = 5;'],
+    ['let coord: Pair<number>', 'let coord;'],
     ['let coord: Pair<number>', 'let coord;'],
     ['let coord: { a: string }', 'let coord;'],
     ['const coord: Pair<number> = 5', 'const coord = 5;'],


### PR DESCRIPTION
Add all syntax definitions as found in spec. Along the way, I also found bugs, so added them.
To help me along, I added a "qa" test that is skipped by default, but which is easy to try out things with.

All failing tests are commented out and marked with "TODO".
